### PR TITLE
add `/loc` endpoint to use the geolocation api to display user coords

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Free2Pee.jl
 
 Contains functions for querying the overpass API to get locations on OSM with bathrooms.
+
+demo:
+
+https://user-images.githubusercontent.com/33790004/220440249-7af425ee-d2dd-49d3-b844-4a67bc831b0f.mp4

--- a/src/Free2Pee.jl
+++ b/src/Free2Pee.jl
@@ -25,58 +25,58 @@ function lat_long_pair(n)
     return (n["lat"], n["lon"])
 end
 
-function gen_query(lat, lon)
+function gen_query(lat, lon; radius=1000)
     """
     [out:json];
     (
-        node(around:1000, $lat, $lon)["amenity"="toilets"];
-        node(around:1000, $lat, $lon)["toilets:position"="seated"];
-        node(around:1000, $lat, $lon)["toilets:position"="urinal"];
-        node(around:1000, $lat, $lon)["toilets:position"="squat"];
-        node(around:1000, $lat, $lon)["toilets:position"="seated;urinal"];
-        node(around:1000, $lat, $lon)["changing_table"="yes"];
-        node(around:1000, $lat, $lon)["changing_table"="no"];
-        node(around:1000, $lat, $lon)["changing_table:location"];
-        node(around:1000, $lat, $lon)["changing_table:location"="female_toilet"];
-        node(around:1000, $lat, $lon)["changing_table:location"="male_toilet"];
-        node(around:1000, $lat, $lon)["changing_table:location"="wheelchair_toilet"];
-        node(around:1000, $lat, $lon)["changing_table:location"="dedicated_room"];
-        node(around:1000, $lat, $lon)["toilets:handwashing"="yes"];
-        node(around:1000, $lat, $lon)["toilets:handwashing"="no"];
-        node(around:1000, $lat, $lon)["toilets:paper_supplied"="yes"];
-        node(around:1000, $lat, $lon)["toilets:paper_supplied"="no"];
-        node(around:1000, $lat, $lon)["toilets"="yes"];
-        node(around:1000, $lat, $lon)["toilets:access"];
-        node(around:1000, $lat, $lon)["toilets:fee"="yes"];
-        node(around:1000, $lat, $lon)["toilets:fee"="no"];
-        node(around:1000, $lat, $lon)["toilets:charge"];
-        node(around:1000, $lat, $lon)["toilets:wheelchair"="yes"];
-        node(around:1000, $lat, $lon)["toilets:wheelchair"="no"];
-        node(around:1000, $lat, $lon)["toilets:wheelchair"="designated"];
-        node(around:1000, $lat, $lon)["toilets:door:width"];
-        node(around:1000, $lat, $lon)["toilets:position"="seated"];
-        node(around:1000, $lat, $lon)["toilets:position"="urinal"];
-        node(around:1000, $lat, $lon)["toilets:position"="squat"];
-        node(around:1000, $lat, $lon)["toilets:position"="seated;urinal"];
-        node(around:1000, $lat, $lon)["changing_table"="yes"];
-        node(around:1000, $lat, $lon)["changing_table"="no"];
-        node(around:1000, $lat, $lon)["changing_table:location"];
-        node(around:1000, $lat, $lon)["changing_table:location"="female_toilet"];
-        node(around:1000, $lat, $lon)["changing_table:location"="male_toilet"];
-        node(around:1000, $lat, $lon)["changing_table:location"="wheelchair_toilet"];
-        node(around:1000, $lat, $lon)["changing_table:location"="dedicated_room"];
-        node(around:1000, $lat, $lon)["toilets:handwashing"="yes"];
-        node(around:1000, $lat, $lon)["toilets:handwashing"="no"];
-        node(around:1000, $lat, $lon)["toilets:paper_supplied"="yes"];
-        node(around:1000, $lat, $lon)["toilets:paper_supplied"="no"];
-        node(around:1000, $lat, $lon)["toilets:description"];
+        node(around:$radius, $lat, $lon)["amenity"="toilets"];
+        node(around:$radius, $lat, $lon)["toilets:position"="seated"];
+        node(around:$radius, $lat, $lon)["toilets:position"="urinal"];
+        node(around:$radius, $lat, $lon)["toilets:position"="squat"];
+        node(around:$radius, $lat, $lon)["toilets:position"="seated;urinal"];
+        node(around:$radius, $lat, $lon)["changing_table"="yes"];
+        node(around:$radius, $lat, $lon)["changing_table"="no"];
+        node(around:$radius, $lat, $lon)["changing_table:location"];
+        node(around:$radius, $lat, $lon)["changing_table:location"="female_toilet"];
+        node(around:$radius, $lat, $lon)["changing_table:location"="male_toilet"];
+        node(around:$radius, $lat, $lon)["changing_table:location"="wheelchair_toilet"];
+        node(around:$radius, $lat, $lon)["changing_table:location"="dedicated_room"];
+        node(around:$radius, $lat, $lon)["toilets:handwashing"="yes"];
+        node(around:$radius, $lat, $lon)["toilets:handwashing"="no"];
+        node(around:$radius, $lat, $lon)["toilets:paper_supplied"="yes"];
+        node(around:$radius, $lat, $lon)["toilets:paper_supplied"="no"];
+        node(around:$radius, $lat, $lon)["toilets"="yes"];
+        node(around:$radius, $lat, $lon)["toilets:access"];
+        node(around:$radius, $lat, $lon)["toilets:fee"="yes"];
+        node(around:$radius, $lat, $lon)["toilets:fee"="no"];
+        node(around:$radius, $lat, $lon)["toilets:charge"];
+        node(around:$radius, $lat, $lon)["toilets:wheelchair"="yes"];
+        node(around:$radius, $lat, $lon)["toilets:wheelchair"="no"];
+        node(around:$radius, $lat, $lon)["toilets:wheelchair"="designated"];
+        node(around:$radius, $lat, $lon)["toilets:door:width"];
+        node(around:$radius, $lat, $lon)["toilets:position"="seated"];
+        node(around:$radius, $lat, $lon)["toilets:position"="urinal"];
+        node(around:$radius, $lat, $lon)["toilets:position"="squat"];
+        node(around:$radius, $lat, $lon)["toilets:position"="seated;urinal"];
+        node(around:$radius, $lat, $lon)["changing_table"="yes"];
+        node(around:$radius, $lat, $lon)["changing_table"="no"];
+        node(around:$radius, $lat, $lon)["changing_table:location"];
+        node(around:$radius, $lat, $lon)["changing_table:location"="female_toilet"];
+        node(around:$radius, $lat, $lon)["changing_table:location"="male_toilet"];
+        node(around:$radius, $lat, $lon)["changing_table:location"="wheelchair_toilet"];
+        node(around:$radius, $lat, $lon)["changing_table:location"="dedicated_room"];
+        node(around:$radius, $lat, $lon)["toilets:handwashing"="yes"];
+        node(around:$radius, $lat, $lon)["toilets:handwashing"="no"];
+        node(around:$radius, $lat, $lon)["toilets:paper_supplied"="yes"];
+        node(around:$radius, $lat, $lon)["toilets:paper_supplied"="no"];
+        node(around:$radius, $lat, $lon)["toilets:description"];
     );
     out;
     """
 end
 
-function to_df(lat, lon)
-    query = gen_query(lat, lon)
+function to_df(lat, lon; radius=1000)
+    query = gen_query(lat, lon; radius)
     response = HTTP.post(OVERPASS_URL, nothing, query)
     j = JSON3.read(response.body)
     es = j.elements

--- a/test/overpass_api.jl
+++ b/test/overpass_api.jl
@@ -34,6 +34,7 @@ end
 end
 
 @get "/" function (req::HTTP.Request)
+    dump(req)
     HTTP.Response(200, ["Content-Type" => "text/html"]; body="""
     <html>
     <head>
@@ -82,8 +83,9 @@ function getLocation() {
 }
 
 function showPosition(position) {
-    x.innerHTML="Latitude: " + position.coords.latitude + 
-    "<br>Longitude: " + position.coords.longitude;  
+    href = "/" + position.coords.latitude + "/" + position.coords.longitude
+    s = `<a href=\"\${href}">BINGBONG</a>`
+    x.innerHTML=s;
 }
 </script>
 

--- a/test/overpass_api.jl
+++ b/test/overpass_api.jl
@@ -6,52 +6,47 @@ const LAT = 42.35810736568732
 const LON = -71.10592447014132
 
 function foo(tag, url)
-    if haskey(tag, :name) 
+    if haskey(tag, :name)
         name = tag.name
         HtmlCell{String}("<a href=\"$url\">$name</a>")
-    else 
+    else
         HtmlCell{String}("<a href=\"$url\">BingBong</a>")
     end
 end
 
 @get "/{lat}/{lon}" function foo(req::HTTP.Request, lat, lon)
+    qps = Oxygen.queryparams(req)
+
+    if haskey(qps, "radius")
+        radius = parse(Int, qps["radius"])
+    else
+        radius = 1000
+    end
+
     lat = parse(Float64, lat)
     lon = parse(Float64, lon)
-    df = Free2Pee.to_df(lat, lon)
-    view_df = df[:, [:id, :distance, :lat, :lon, :maps_url]]
+    df = Free2Pee.to_df(lat, lon; radius)
     atags = []
+    node_atags = map(x->HtmlCell{String}("<a href=\"https://www.openstreetmap.org/node/$x\">$x</a>"), df.id)
+    
     for r in eachrow(df)
         atag = foo(r.tags, r.maps_url)
         push!(atags, atag)
     end
-
+    
+    view_df = df[:, [:id, :distance, :lat, :lon, :maps_url]]
     view_df.maps_url = atags
+    view_df.id = node_atags
+
     sort!(view_df, :distance)
     io = IOBuffer()
     pretty_table(io, view_df, nosubheader=true, backend=Val(:html); allow_html_in_cells=true)
-    
+
     HTTP.Response(200, ["Content-Type" => "text/html"]; body=take!(io))
 end
 
+# "using window.location.replace might not be the best"
 @get "/" function (req::HTTP.Request)
-    dump(req)
-    HTTP.Response(200, ["Content-Type" => "text/html"]; body="""
-    <html>
-    <head>
-    <title>Free2Pee</title>
-    </head>
-    <body>
-    <h1>Free2Pee</h1>
-    <p>Find the nearest public toilets</p>
-    <form action="/$LAT/$LON">
-    <input type="submit" value="Submit">
-    </form>
-    </body>
-    </html>
-    """)
-end
-
-@get "/loc" function (req::HTTP.Request)
     HTTP.Response(200, ["Content-Type" => "text/html"]; body="""
 <!DOCTYPE html>
 <html>
@@ -84,8 +79,7 @@ function getLocation() {
 
 function showPosition(position) {
     href = "/" + position.coords.latitude + "/" + position.coords.longitude
-    s = `<a href=\"\${href}">BINGBONG</a>`
-    x.innerHTML=s;
+    window.location.replace(href);
 }
 </script>
 
@@ -102,21 +96,21 @@ headers = [
 ]
 
 function CorsHandler(handle)
-    return function(req::HTTP.Request)
+    return function (req::HTTP.Request)
         # return headers on OPTIONS request
         if HTTP.method(req) == "OPTIONS"
             return HTTP.Response(200, headers)
-        else 
+        else
             return handle(req)
         end
     end
 end
 
-    # start the web server
+# start the web server
 # serve(host="0.0.0.0", middleware=[CorsHandler])
-serve(;middleware=[CorsHandler])
+serve(; middleware=[CorsHandler])
 
-    # serve(;host="10.0.0.224")
+# serve(;host="10.0.0.224")
 # serve(;port=8080)
 
 # try this not haversine

--- a/test/overpass_api.jl
+++ b/test/overpass_api.jl
@@ -50,6 +50,48 @@ end
     """)
 end
 
+@get "/loc" function (req::HTTP.Request)
+    HTTP.Response(200, ["Content-Type" => "text/html"]; body="""
+<!DOCTYPE html>
+<html>
+<body>
+
+<p id="demo">Click the button to get your coordinates:</p>
+
+<button onclick="getLocation()">Try It</button>
+
+<script>
+var x = document.getElementById("demo");
+
+function getLocation() {
+    if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+            // Success function
+            showPosition, 
+            // Error function
+            null, 
+            // Options. See MDN for details.
+            {
+               enableHighAccuracy: true,
+               timeout: 5000,
+               maximumAge: 0
+            });
+    } else { 
+        x.innerHTML = "Geolocation is not supported by this browser.";
+    }
+}
+
+function showPosition(position) {
+    x.innerHTML="Latitude: " + position.coords.latitude + 
+    "<br>Longitude: " + position.coords.longitude;  
+}
+</script>
+
+</body>
+</html>
+    """)
+end
+
 # CORS headers that show what kinds of complex requests are allowed to API
 headers = [
     "Access-Control-Allow-Origin" => "*",
@@ -69,7 +111,8 @@ function CorsHandler(handle)
 end
 
     # start the web server
-serve(host="0.0.0.0", middleware=[CorsHandler])
+# serve(host="0.0.0.0", middleware=[CorsHandler])
+serve(;middleware=[CorsHandler])
 
     # serve(;host="10.0.0.224")
 # serve(;port=8080)


### PR DESCRIPTION
to close #2 

@michaelfortunato 

https://stackoverflow.com/questions/26354472/how-can-i-get-users-location-without-asking-for-the-permission-or-if-user-permi

https://codepen.io/sebastienfi/pen/pqNxEa
This codepen link is a simple demo that displays prompts the user to allow giving their location, then simply displays it. 

So I copied that html and put it in an Oxygen endpoint, and that works, in the sense that we can do everything that demo does. The part where I'm getting tripped up is how to actually use or store that data (not just display it). 

Is there a way to change this handler to basically redirect the browser to the `/lat/lon` endpoint?
Also, since you mentioned user agent string, could we just set the user-agent so that all subsequent calls to the site from a given IP will send over the coordinates and we can just unwrap that from the `HTTP.Request`

```js
function showPosition(position) {
    x.innerHTML="Latitude: " + position.coords.latitude + 
    "<br>Longitude: " + position.coords.longitude;  
}
```
